### PR TITLE
Fix dependencies

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -24,13 +24,13 @@ jobs:
         with:
           images: liuyunhao1578/deformsim
           # generate Docker tags based on the following events/attributes
+          # ref pr ---> will be ignored
+          # semver version ---> 0.1.3
+          # semver major.minor ---> 0.1
           tags: |
-            type=ref,event=tag
             type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
-            type=sha
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM liuyunhao1578/deformsim:0.1
+FROM liuyunhao1578/deformsim:latest
 
-COPY . /opt/PlasticineLab-latest/
-RUN pip3 install -e /opt/PlasticineLab-latest/
+COPY . /opt/PlasticineLab/
+RUN pip3 install -e /opt/PlasticineLab/
 RUN mkdir -p ~/output
 
 CMD /bin/bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM liuyunhao1578/deformsim:latest
 
 COPY . /opt/PlasticineLab/
-RUN pip3 install -e /opt/PlasticineLab/
 RUN mkdir -p ~/output
 
-CMD /bin/bash
+CMD pip3 install -e /opt/PlasticineLab/ && /bin/bash

--- a/scripts/auto-tag
+++ b/scripts/auto-tag
@@ -1,0 +1,17 @@
+#!/bin/bash
+versionLine=$(docker image inspect liuyunhao1578/deformsim:latest | grep -i "image.version")
+major=`echo ${versionLine#*:} | sed 's/\"//g' | cut -d. -f1`
+minor=`echo ${versionLine#*:} | sed 's/\"//g' | cut -d. -f2`
+patch=`echo ${versionLine#*:} | sed 's/\"//g' | cut -d. -f3`
+echo -e "\033[34mOrigin tag ${major}.${minor}.${patch}[0m"
+let patch=patch+1
+echo -e "\033[34mNew tag ${major}.${minor}.${patch}\033[0m"
+tag="v${major}.${minor}.${patch}"
+echo
+echo -e "\033[33mExectuing\033[0m git tag ${tag}"
+git tag $tag
+
+echo -e "\033[33mExectuing\033[0m git push origin ${tag}"
+echo -e "\033[33mThis triggers AUTO-PUBLISH, confirm?\033[0m"
+read
+git push origin $tag

--- a/scripts/auto-tag
+++ b/scripts/auto-tag
@@ -1,9 +1,9 @@
 #!/bin/bash
-versionLine=$(docker image inspect liuyunhao1578/deformsim:latest | grep -i "image.version")
+versionLine=$(docker image inspect liuyunhao1578/deformsim:latest | grep -i "image.version" | tail -1)
 major=`echo ${versionLine#*:} | sed 's/\"//g' | cut -d. -f1`
 minor=`echo ${versionLine#*:} | sed 's/\"//g' | cut -d. -f2`
 patch=`echo ${versionLine#*:} | sed 's/\"//g' | cut -d. -f3`
-echo -e "\033[34mOrigin tag ${major}.${minor}.${patch}[0m"
+echo -e "\033[34mOrigin tag ${major}.${minor}.${patch}\033[0m"
 let patch=patch+1
 echo -e "\033[34mNew tag ${major}.${minor}.${patch}\033[0m"
 tag="v${major}.${minor}.${patch}"

--- a/scripts/auto-tag
+++ b/scripts/auto-tag
@@ -1,8 +1,8 @@
 #!/bin/bash
-versionLine=$(docker image inspect liuyunhao1578/deformsim:latest | grep -i "image.version" | tail -1)
+versionLine=$(docker image inspect liuyunhao1578/deformsim:latest | grep -i "RepoTags" -A 1 | tail -1)
 major=`echo ${versionLine#*:} | sed 's/\"//g' | cut -d. -f1`
 minor=`echo ${versionLine#*:} | sed 's/\"//g' | cut -d. -f2`
-patch=`echo ${versionLine#*:} | sed 's/\"//g' | cut -d. -f3`
+patch=`echo ${versionLine#*:} | sed 's/\",//g' | cut -d. -f3`
 echo -e "\033[34mOrigin tag ${major}.${minor}.${patch}\033[0m"
 let patch=patch+1
 echo -e "\033[34mNew tag ${major}.${minor}.${patch}\033[0m"

--- a/scripts/dev-deploy
+++ b/scripts/dev-deploy
@@ -9,6 +9,25 @@ SHELL_DIR=$(dirname "$0")
 DEV_IMAGE=$1
 shift
 
+CACHE_CONTAINER=`docker container ls -a | grep ${DEV_IMAGE}`
+if [ -n "$CACHE_CONTAINER" ]; then
+	echo -e "\033[33mThere are cached container instance(s) of this image\nAre you to rebuild the image or use the cached one?\033[0m"
+	echo -e "1) Use the cached one \033[34m[DEFAULT]\033[0m"
+	echo    "2) Re-build the image and run a new container anyway"
+	read -p "1 or 2?"
+	if [ $REPLY == '1' ]; then
+		container=`docker start ${CACHE_CONTAINER:0:12}`
+		echo -e "\033[34mThe container has been started at \033[0m${container}\033[34m in the background."
+		echo -e "You can attach to it using this hash\033[0m"
+		exit
+	elif [ $REPLY == '2' ]; then
+		docker container rm ${CACHE_CONTAINER:0:12}
+	else
+		echo -e "\033[33mInvalid reply: $REPLY\033[0m"
+		exit
+	fi
+fi
+
 # build the image if not existing
 IMAGE_TAG_FROM_NAME=(${DEV_IMAGE//:/ })
 entry=`docker images | grep -E "${IMAGE_TAG_FROM_NAME[0]}\s+${IMAGE_TAG_FROM_NAME[1]}"`
@@ -31,4 +50,5 @@ else
 fi
 echo -e "\033[34mExecuting\033[0m nvidia-docker run $maps -dit $DEV_IMAGE /bin/bash"
 container=`nvidia-docker run $maps -dit $DEV_IMAGE /bin/bash`
-echo -e "\033[34mThe container has been started at \033[0m${container:0:12}\033[34m in the background. You can attach to it using this hash\033[0m"
+echo -e "\033[34mThe container has been started at \033[0m${container:0:12}\033[34m in the background."
+echo -e "You can attach to it using this hash\033[0m"

--- a/scripts/dev-deploy
+++ b/scripts/dev-deploy
@@ -1,6 +1,4 @@
 #!/bin/bash
-echo -e "\033[32mChecking for Docker image version\033[0m"
-docker pull liuyunhao1578/deformsim:latest &> /dev/null
 if [ $# == 0 ]; then
 	echo -e "\033[33mno working dir specified\033[0m"
 else

--- a/scripts/dev-deploy
+++ b/scripts/dev-deploy
@@ -1,0 +1,19 @@
+#!/bin/bash
+echo -e "\033[32mChecking for Docker image version\033[0m"
+docker pull liuyunhao1578/deformsim:latest &> /dev/null
+if [ $# == 0 ]; then
+	echo -e "\033[33mno working dir specified\033[0m"
+else
+	paths=$(echo ${@:-1} | tr  "," "\n")
+	echo $paths
+	maps=""
+	for eachpath in $paths
+	do
+		[[ $eachpath != /home* ]] && echo -e "\033[31mThe path must be absolute\033[0m"
+		[[ $eachpath == /home* ]] && inner=$(realpath --relative-to="$HOME" "$eachpath") && maps="${maps} -v ${eachpath}:/root/${inner}"
+	done
+fi
+echo -e "\033[34mExecute the following command to enter the DEV-DEPLOYMENT ENV\033[0m"
+echo
+echo "nvidia-docker run $maps -d liuyunhao1578/deformsim:latest /bin/bash"
+echo

--- a/scripts/dev-deploy
+++ b/scripts/dev-deploy
@@ -5,7 +5,6 @@ if [ $# == 0 ]; then
 	echo -e "\033[33mno working dir specified\033[0m"
 else
 	paths=$(echo ${@:-1} | tr  "," "\n")
-	echo $paths
 	maps=""
 	for eachpath in $paths
 	do

--- a/scripts/dev-deploy
+++ b/scripts/dev-deploy
@@ -12,7 +12,7 @@ shift
 # build the image if not existing
 IMAGE_TAG_FROM_NAME=(${DEV_IMAGE//:/ })
 entry=`docker images | grep -E "${IMAGE_TAG_FROM_NAME[0]}\s+${IMAGE_TAG_FROM_NAME[1]}"`
-[[ -z $entry ]] && bash "${SHELL_DIR}/new-docker" "$DEV_IMAGE" || echo -e "\033[34mDocker image exists; skip building"
+[[ -z $entry ]] && bash "${SHELL_DIR}/new-docker" "$DEV_IMAGE" || echo -e "\033[33mDocker image exists; skip building\033[0m"
 
 # do the file mapping
 if [ $# == 0 ]; then
@@ -30,4 +30,5 @@ else
 	done
 fi
 echo -e "\033[34mExecuting\033[0m nvidia-docker run $maps -dit $DEV_IMAGE /bin/bash"
-nvidia-docker run $maps -dit $DEV_IMAGE /bin/bash
+container=`nvidia-docker run $maps -dit $DEV_IMAGE /bin/bash`
+echo -e "\033[34mThe container has been started at \033[0m${container:0:12}\033[34m in the background. You can attach to it using this hash\033[0m"

--- a/scripts/dev-deploy
+++ b/scripts/dev-deploy
@@ -1,8 +1,27 @@
 #!/bin/bash
+
+# check the inputs
+if [ $# -le 1 ]; then
+	echo -e "\033[33mdev-deploy [image]:[tag] [paths to be mapped]...\033[0m"
+	exit
+fi
+SHELL_DIR=$(dirname "$0")
+DEV_IMAGE=$1
+shift
+
+# build the image if not existing
+IMAGE_TAG_FROM_NAME=(${DEV_IMAGE//:/ })
+entry=`docker images | grep -E "${IMAGE_TAG_FROM_NAME[0]}\s+${IMAGE_TAG_FROM_NAME[1]}"`
+[[ -z $entry ]] && bash "${SHELL_DIR}/new-docker" "$DEV_IMAGE" || echo -e "\033[34mDocker image exists; skip building"
+
+# do the file mapping
 if [ $# == 0 ]; then
-	echo -e "\033[33mno working dir specified\033[0m"
+	echo -e "\033[33mno working dir specified. Using the current folder\033[0m"
+	eachpath=`pwd`
+	inner=$(realpath --relative-to="$HOME" "$eachpath")
+	maps="-v $(eachpath):/root/${inner}"
 else
-	paths=$(echo ${@:-1} | tr  "," "\n")
+	paths=$(echo $@ | tr  "," "\n")
 	maps=""
 	for eachpath in $paths
 	do
@@ -10,7 +29,5 @@ else
 		[[ $eachpath == /home* ]] && inner=$(realpath --relative-to="$HOME" "$eachpath") && maps="${maps} -v ${eachpath}:/root/${inner}"
 	done
 fi
-echo -e "\033[34mExecute the following command to enter the DEV-DEPLOYMENT ENV\033[0m"
-echo
-echo "nvidia-docker run $maps -d liuyunhao1578/deformsim:latest /bin/bash"
-echo
+echo -e "\033[34mExecuting\033[0m nvidia-docker run $maps -dit $DEV_IMAGE /bin/bash"
+nvidia-docker run $maps -dit $DEV_IMAGE /bin/bash

--- a/scripts/new-docker
+++ b/scripts/new-docker
@@ -1,0 +1,5 @@
+#!/bin/bash
+IMAGE_NAME=$1
+echo -e "\033[33mNo such image:$IMAGE_NAME\n\033[34mRebuilding\033[0m"
+REPO_DIR=$(cd "$(dirname "$0")";cd ..;pwd)
+docker build -t $IMAGE_NAME $REPO_DIR

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ install_requires = [
     'baselines',
     'pandas',
     'seaborn',
-    'image.io'
+    'imageio'
 ]
 
 setup(name='plb',


### PR DESCRIPTION
# Summary

Fix some dependencies & modify the CI issues

## Patch briefing

### `.github/workflows/docker-publish.yml`
remove unnecessary DockerHub tags

### `Dockerfile`
- use the latest version instead of a static version
    NOTE: the latest version will be automatically updated through the CI pipeline
- remove the original PlasticineLab code, and copy the current git repo content to the /opt/PlasticineLab directory
- not install the PLB until being deployed
   The benefit of this delay installing in the development mode (instead of product deploying), the `nvidia-docker run -it <docker image name>:<tag> <cmd>` will override the pip installing instruction in the Dockerfile

### `scripts/auto-tag`
- automatically update the patch field of a tag and trigger a CI build
- to avoid incorrect tagging

### `scripts/dev-deploy`
The script will do the following things for the convenience during development
1. Pull the latest docker image
2. Map the given folder into the container when start

# Test
## Unit test
N/A
## Functionality test
- [x] Docker build ![Docker build](https://img.shields.io/github/workflow/status/fyp21011/PlasticineLab/Docker)
- [x] Execution of `scripts/dev-deploy`:  
![image](https://user-images.githubusercontent.com/43565614/140382080-c1489924-9835-482a-b1f7-fe837e45d461.png)
- [x] Dry run `scripts/auto-tag`:
![image](https://user-images.githubusercontent.com/43565614/140382662-77503083-c548-4165-b60c-6807ed3632c3.png)

close #9 