### PR TITLE
Dev gradient

### DIFF
--- a/plb/engine/controller.py
+++ b/plb/engine/controller.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod, abstractproperty
 from typing import Any, Callable, Union
-import numpy
 
+import numpy
 import torch
 
 

--- a/plb/engine/controller.py
+++ b/plb/engine/controller.py
@@ -1,4 +1,4 @@
-from abc import ABC, abstractmethod, abstractproperty
+from abc import ABC, abstractmethod
 from typing import Any, Callable, Union
 
 import numpy
@@ -45,12 +45,34 @@ class DiffFKWrapper:
             self._grad_handler(substep)
 
 class Controller(ABC):
-    @abstractproperty
-    def forward_kinematics(self) -> DiffFKWrapper:
+    def __init__(self) -> None:
+        self.forward_kinematics = DiffFKWrapper(self._forward_kinematics, self._forward_kinematics_grad)
         """ For both forward kinematics and the backpropagation
 
         * `self.forward_kinematics(s)`: applies the FK till time `s`
         * `self.forward_kinematics.grad(s)`: backpropagation from time `s`
+        """
+
+    @abstractmethod
+    def _forward_kinematics(self, step_idx: int) -> None:
+        """ Compute the forward kinematics based on previously set actions
+        through `self.set_action`. 
+
+        Wrapped in the `self.forward_kinematics` callable property, such that
+        `self.forward_kinematics(s)` invokes this method
+
+        Params
+        ------
+        step_idx: the step index
+        """
+        pass
+
+    @abstractmethod
+    def _forward_kinematics_grad(self, step_idx: int):
+        """ Gradient method for `self._forward_kinematics`
+
+        Wrapped in the `self.forward_kinematics` , such that
+        `self.forward_kinematics.grad(s)` invokes this method
         """
         pass
 

--- a/plb/engine/controller.py
+++ b/plb/engine/controller.py
@@ -1,4 +1,4 @@
-from abc import ABC, abstractmethod
+from abc import ABC, abstractmethod, abstractproperty
 from typing import Any, Callable, Union
 
 import numpy
@@ -52,6 +52,13 @@ class Controller(ABC):
         * `self.forward_kinematics(s)`: applies the FK till time `s`
         * `self.forward_kinematics.grad(s)`: backpropagation from time `s`
         """
+
+    @abstractproperty
+    def not_empty(self) -> bool:
+        """ Whether the controller controls something
+        or nothing (dummy controller)
+        """
+        pass
 
     @abstractmethod
     def _forward_kinematics(self, step_idx: int) -> None:

--- a/plb/engine/controller.py
+++ b/plb/engine/controller.py
@@ -1,0 +1,81 @@
+from abc import ABC, abstractmethod, abstractproperty
+from typing import Any, Callable, Union
+import numpy
+
+import torch
+
+
+class DiffFKWrapper:
+    """ Wrapper of differentiable forward kinematics for `Controller`
+
+    Two callable handlers, one for forward kinemtaics, one
+    for the gradient backpropagation, are wrapped inside. 
+
+    Params
+    ------
+    `fk_handler`: the handler for forward kinematics
+    `fk_grad_handler`: the handler for gradient backpropagation of
+        forward kinematics
+    """
+    def __init__(self, fk_handler: Callable[[int], None], fk_grad_handler: Callable[[int], None]) -> None:
+        self._fk_handler = fk_handler
+        self._grad_handler = fk_grad_handler
+
+    def __call__(self, substep: int) -> None:
+        """ Forward kinematics computation
+
+        Params
+        ------
+        substep: the index of the substep when the forward
+            kinematics is computed
+        """
+        if self._fk_handler != None:
+            self._fk_handler(substep)
+
+    def grad(self, substep: int) -> None:
+        """ Backpropagate along the computation graph for
+        forward kinematics
+
+        Params
+        ------
+        substep: the index of the substep from which the
+            backpropagation starts
+        """
+        if self._grad_handler != None:
+            self._grad_handler(substep)
+
+class Controller(ABC):
+    @abstractproperty
+    def forward_kinematics(self) -> DiffFKWrapper:
+        """ For both forward kinematics and the backpropagation
+
+        * `self.forward_kinematics(s)`: applies the FK till time `s`
+        * `self.forward_kinematics.grad(s)`: backpropagation from time `s`
+        """
+        pass
+
+    @abstractmethod
+    def set_action(self, step: int, n_substep: int, action: Any) -> None:
+        """ Set action for time [step * n_substep, (step + 1) * n_substep)
+
+        Params
+        ------
+        step: step index
+        n_substep: how many substeps one step contains
+        action: the actions
+        """
+        pass
+
+    @abstractmethod
+    def get_step_grad(self, step: int) -> Union[torch.Tensor, numpy.ndarray, Any]:
+        """ Get the gradient of a specified step
+        
+        Params
+        ------
+        step: index of step where the action gradient is concerned
+
+        Returns
+        -------
+        Gradient, of type Tensor, NDArray or Taichi Field
+        """
+        pass

--- a/plb/engine/mpm_simulator.py
+++ b/plb/engine/mpm_simulator.py
@@ -506,10 +506,13 @@ class MPMSimulator:
 
         # This get the gradient for a action
         actuation_grad = self.fpc.get_step_grad(cur) # The free primitives' gradient
-        joint_velocity_grad = self.rc.get_step_grad(cur) # The joint-level primitives
+        if self.rc.not_empty:
+            joint_velocity_grad = self.rc.get_step_grad(cur) # The joint-level primitives
+            clipped_actuation_grad = torch.cat((torch.from_numpy(actuation_grad), joint_velocity_grad))
+        else:
+            clipped_actuation_grad = torch.from_numpy(actuation_grad)
 
         # grad preprocessing
-        clipped_actuation_grad = torch.cat((torch.from_numpy(actuation_grad), joint_velocity_grad))
         # nn.utils.clip_grad_norm_(clipped_actuation_grad, max_norm=1.0, norm_type=2)
         nn.utils.clip_grad_value_(clipped_actuation_grad, clip_value=1.0)
 

--- a/plb/engine/mpm_simulator.py
+++ b/plb/engine/mpm_simulator.py
@@ -1,6 +1,7 @@
 from typing import Iterable
-import taichi as ti
+
 import numpy as np
+import taichi as ti
 import torch
 import torch.nn as nn
 

--- a/plb/engine/primitive/primitives.py
+++ b/plb/engine/primitive/primitives.py
@@ -286,11 +286,11 @@ class Primitives(Controller):
         """
 
     def _forward_kinematics(self, s):
-        for i in range(self.primitives.n):
+        for i in range(self.n):
             self.primitives[i].forward_kinematics(s)
 
     def _forward_kinematics_grad(self, s):
-        for i in range(self.primitives.n-1, -1, -1):
+        for i in range(self.n-1, -1, -1):
             self.primitives[i].forward_kinematics.grad(s)
 
     @property

--- a/plb/engine/primitive/primitives.py
+++ b/plb/engine/primitive/primitives.py
@@ -4,7 +4,7 @@ import numpy as np
 import taichi as ti
 from yacs.config import CfgNode as CN
 
-from ..controller import Controller, DiffFKWrapper
+from ..controller import Controller
 from .primive_base import Primitive
 from .utils import qrot, qmul, w2quat
 
@@ -283,13 +283,6 @@ class Primitives(Controller):
         Those primitives created & controlled by robots
         will not be counted here
         """
-
-        self._diff_fk = DiffFKWrapper(self._forward_kinematics,
-            self._forward_kinematics_grad)
-
-    @property
-    def forward_kinematics(self):
-        return self._diff_fk
 
     def _forward_kinematics(self, s):
         for i in range(self.primitives.n):

--- a/plb/engine/primitive/primitives.py
+++ b/plb/engine/primitive/primitives.py
@@ -1,10 +1,11 @@
-import taichi as ti
-import numpy as np
 import yaml
 
-from plb.engine.controller import Controller, DiffFKWrapper
-from .primive_base import Primitive
+import numpy as np
+import taichi as ti
 from yacs.config import CfgNode as CN
+
+from ..controller import Controller, DiffFKWrapper
+from .primive_base import Primitive
 from .utils import qrot, qmul, w2quat
 
 @ti.func

--- a/plb/engine/primitive/primitives.py
+++ b/plb/engine/primitive/primitives.py
@@ -262,6 +262,7 @@ class Box(Primitive):
 
 class Primitives(Controller):
     def __init__(self, cfgs, max_timesteps=1024):
+        super().__init__()
         outs = []
         self.primitives = []
         for i in cfgs:

--- a/plb/engine/primitive/primitives.py
+++ b/plb/engine/primitive/primitives.py
@@ -293,6 +293,10 @@ class Primitives(Controller):
             self.primitives[i].forward_kinematics.grad(s)
 
     @property
+    def not_empty(self) -> bool:
+        return len(self.primitives) > 0
+
+    @property
     def action_dim(self):
         return self.action_dims[-1]
 

--- a/plb/engine/primitive/primive_base.py
+++ b/plb/engine/primitive/primive_base.py
@@ -155,9 +155,10 @@ class Primitive:
         targetXYZ = xyz_quat[:3]
         targetQuat = xyz_quat[3:]
 
-        self.position[frameIdx + 1] = max(
-            min(targetXYZ, self.xyz_limit[1]),
-            self.xyz_limit[0]
+        self.position[frameIdx + 1] = np.clip(
+            targetXYZ,
+            self.xyz_limit[0].value,
+            self.xyz_limit[1].value
         )
         self.rotation[frameIdx + 1] = targetQuat
 
@@ -168,7 +169,7 @@ class Primitive:
             grads[i] = self.position.grad[frameIdx + 1][i]
         for i in range(4):
             grads[3 + i] = self.rotation.grad[frameIdx + 1][i]
-        xyz_quat.backward(grads)
+        xyz_quat.backward(grads, retain_graph=True)
 
 
     # state set and copy ...

--- a/plb/engine/robots.py
+++ b/plb/engine/robots.py
@@ -69,6 +69,10 @@ class RobotsController(Controller):
         * `self.flatten_actions[3]` are the one to be executed next
         """
 
+    @property
+    def not_empty(self) -> bool:
+        return len(self.robots) > 0
+
     @classmethod
     def parse_config(cls, cfgs: List[Union[CN, str]], primitiveController: Primitives) -> "RobotsController":
         """ Parse the YAML configuration node for `Robots`

--- a/plb/engine/robots.py
+++ b/plb/engine/robots.py
@@ -11,7 +11,7 @@ from plb.config.utils import make_cls_config
 from plb.urdfpy import DiffRobot, Robot, Collision
 from plb.engine.primitive.primitives import Box, Primitives, Sphere, Cylinder, Primitive
 
-ROBOT_LINK_DOF = 6
+ROBOT_LINK_DOF = 7
 ROBOT_LINK_DOF_SCALE = tuple((0.01 for _ in range(ROBOT_LINK_DOF)))
 ROBOT_COLLISION_COLOR = '(0.8, 0.8, 0.8)'
 

--- a/plb/engine/robots.py
+++ b/plb/engine/robots.py
@@ -11,7 +11,7 @@ from plb.config.utils import make_cls_config
 from plb.urdfpy import DiffRobot, Robot, Collision
 from plb.engine.primitive.primitives import Box, Primitives, Sphere, Cylinder, Primitive
 
-ROBOT_LINK_DOF = 7
+ROBOT_LINK_DOF = 6
 ROBOT_LINK_DOF_SCALE = tuple((0.01 for _ in range(ROBOT_LINK_DOF)))
 ROBOT_COLLISION_COLOR = '(0.8, 0.8, 0.8)'
 

--- a/plb/engine/robots.py
+++ b/plb/engine/robots.py
@@ -52,6 +52,7 @@ class RobotsController(Controller):
     """ A controller that maps robot to primitive links
     """
     def __init__(self) -> None:
+        super().__init__()
         self.robots: List[DiffRobot] = []
         self.robot_action_dims: List[int] = []
         self.link_2_primitives: List[Dict[str, Primitive]] = []
@@ -112,7 +113,14 @@ class RobotsController(Controller):
 
     @classmethod
     def _urdf_collision_to_primitive(cls, collision: Collision, offset: np.ndarray, pose: torch.Tensor) -> Union[Primitive, None]:
-        """
+        """ Converting the URDF's collision geometry to primitive
+
+        Params
+        ------
+        collision: the URDF robot's collision geometry
+        offset: the offset of the robot's position
+        pose: the pose matrix (4 * 4) of this geometry, which
+            records the initial position of the geometry
         """
         if collision.geometry.box is not None:
             linkPrimitive = Box(cfg = _generate_primitive_config(

--- a/plb/engine/taichi_env.py
+++ b/plb/engine/taichi_env.py
@@ -26,16 +26,16 @@ class TaichiEnv:
 
         self.cfg = cfg.ENV
         self.primitives = Primitives(cfg.PRIMITIVES)
-        self.robots_controller = RobotsController.parse_config(cfg.ROBOTS, self.primitives)
+        controller = RobotsController.parse_config(cfg.ROBOTS, self.primitives)
         self.action_dims = self.primitives.action_dims.copy()
-        self.robots_controller.export_action_dims(to = self.action_dims)
+        controller.export_action_dims(to = self.action_dims)
         self.shapes = Shapes(cfg.SHAPES)
         self.init_particles, self.particle_colors = self.shapes.get()
 
         cfg.SIMULATOR.defrost()
         self.n_particles = cfg.SIMULATOR.n_particles = len(self.init_particles)
 
-        self.simulator = MPMSimulator(cfg.SIMULATOR, self.primitives, self.robots_controller)
+        self.simulator = MPMSimulator(cfg.SIMULATOR, self.primitives, controller)
         self.renderer = Renderer(cfg.RENDERER, self.primitives)
 
         if nn:
@@ -103,13 +103,8 @@ class TaichiEnv:
         return np.concatenate((np.concatenate((x[::step_size], v[::step_size]), axis=-1).reshape(-1), s.reshape(-1)))
 
     def step(self, action=None):
-        if action is not None:
-            action = np.r_[
-                action[:self.primitives.action_dim].detach().cpu().numpy() if isinstance(action, torch.Tensor) \
-                    else np.array(action[:self.primitives.action_dim]),
-                self.robots_controller.set_robot_actions(action, self.primitives.action_dim)
-            ]
-
+        if isinstance(action, torch.Tensor):
+            action = action.detach()
         self.simulator.step(is_copy=self._is_copy, action=action)
 
     def compute_loss(self):

--- a/plb/engine/taichi_env.py
+++ b/plb/engine/taichi_env.py
@@ -35,7 +35,7 @@ class TaichiEnv:
         cfg.SIMULATOR.defrost()
         self.n_particles = cfg.SIMULATOR.n_particles = len(self.init_particles)
 
-        self.simulator = MPMSimulator(cfg.SIMULATOR, self.primitives)
+        self.simulator = MPMSimulator(cfg.SIMULATOR, self.primitives, self.robots_controller)
         self.renderer = Renderer(cfg.RENDERER, self.primitives)
 
         if nn:

--- a/plb/envs/rope_robot.yml
+++ b/plb/envs/rope_robot.yml
@@ -33,7 +33,7 @@ ENV:
   loss:
     target_path: envs/data/Rope3D-v1.npy
 ROBOTS:
-  - path: tests/data/ur5/ur5.urdf
+  - path: tests/data/ur5/ur5_primitive.urdf
     offset: (0.01, -0.1, 0.0)
 RENDERER:
   camera_pos: (0.5, 2.5, 2.)

--- a/plb/urdfpy/__init__.py
+++ b/plb/urdfpy/__init__.py
@@ -8,7 +8,7 @@ from .link import Texture, Material, Visual, Link
 from .joint import JointCalibration, JointDynamics, JointLimit, JointMimic, SafetyController, Joint
 from .transmission import Transmission, TransmissionJoint, Actuator
 from .manipulation import Robot, FK_CFG_Type
-from .diff_fk import DiffRobot
+from .diff_fk import DiffRobot, DEVICE
 from .utils import (rpy_to_matrix, matrix_to_rpy, xyz_rpy_to_matrix,
                     matrix_to_xyz_rpy)
 
@@ -18,5 +18,6 @@ __all__ = [
     'JointCalibration', 'JointDynamics', 'JointLimit', 'JointMimic',
     'SafetyController', 'Actuator', 'TransmissionJoint',
     'Transmission', 'Joint', 'Link', 'Robot', 'FK_CFG_Type', 'DiffRobot', 
-    'rpy_to_matrix', 'matrix_to_rpy', 'xyz_rpy_to_matrix', 'matrix_to_xyz_rpy'
+    'rpy_to_matrix', 'matrix_to_rpy', 'xyz_rpy_to_matrix', 'matrix_to_xyz_rpy',
+    'DEVICE'
 ]

--- a/plb/urdfpy/diff_fk.py
+++ b/plb/urdfpy/diff_fk.py
@@ -317,4 +317,4 @@ class DiffRobot(Robot):
         A sequence of gradients of the joints' velocities
         """      
         for diffJoint in self._actuated_joints:
-            yield diffJoint.velocities[timeStep].grad
+            yield diffJoint.velocities[timeStep].grad.reshape((-1))

--- a/plb/urdfpy/diff_fk.py
+++ b/plb/urdfpy/diff_fk.py
@@ -9,7 +9,7 @@ from plb.urdfpy import Robot, Joint, Link
 DEVICE = 'cuda' if torch.cuda.is_available() else 'cpu'
 DEVICE = torch.device(DEVICE)
 
-TIME_INTERVAL = 24
+VELOCITY_SCALE = 1
 
 
 def _tensor_creator(creator: Callable[[Any], torch.Tensor], *value, **kwargs) -> torch.Tensor:
@@ -156,7 +156,7 @@ class DiffJoint:
             raise ValueError(f"Joint: {self._joint.name} expects {self._joint.action_dim}"+\
                 f"-dim velocity, but got {vel.shape if vel.shape else 1}-d velocity")
         
-        self.angle = self.angle + vel * TIME_INTERVAL
+        self.angle = self.angle + vel * VELOCITY_SCALE
         self.velocities.append(vel)
 
     def get_child_pose_diff(self) -> torch.Tensor:
@@ -243,7 +243,7 @@ class DiffLink:
         if pose.shape[-1] != 7:
             raise ValueError(f'pose must either be of shape 4,4 or 7, but got {pose.shape}')
         self.trajectory.append(pose)
-        self.velocities.append((self.trajectory[-1] - self.trajectory[-2]) / TIME_INTERVAL)
+        self.velocities.append((self.trajectory[-1] - self.trajectory[-2]) / VELOCITY_SCALE)
         return self.velocities[-1]
 
 

--- a/plb/urdfpy/diff_fk.py
+++ b/plb/urdfpy/diff_fk.py
@@ -261,7 +261,7 @@ class DiffRobot(Robot):
         self,
         jointActions: Union[None, List[torch.Tensor]],
         link_names: List[str] = None
-    ) -> List[torch.Tensor]:
+    ) -> Dict[str, torch.Tensor]:
         """ Differetiable version of robot.link_fk
 
         Params
@@ -275,8 +275,8 @@ class DiffRobot(Robot):
             returned
         Return
         ------
-        A sequence of the 7-D velocities (XYZ + Quat) of the
-        links specified in link_names. 
+        A mapping from link names to their poses, each
+        being a 7-dim vector
         """
         if link_names == None:
             link_names = self._link_map.keys()
@@ -299,10 +299,11 @@ class DiffRobot(Robot):
             fk[currentLink] = pose4by4
         for link, pose4by4 in fk.items():
             link.move_link(pose4by4)
-        return [
-            self._link_map[linkName].velocities[-1]
+        return {
+            linkName: self._link_map[linkName].trajectory[-1]
             for linkName in link_names
-        ]
+        }
+    
     
     def fk_gradient(self, timeStep: int, linkGrad: Dict[str, torch.Tensor]) -> Generator[torch.Tensor, None, None]:
         """ Backward the gradients from links' velocity at one moment to

--- a/plb/urdfpy/manipulation.py
+++ b/plb/urdfpy/manipulation.py
@@ -70,7 +70,7 @@ class Robot(URDFType):
         self._materials = list(materials)
 
         # Set up private helper maps from name to value
-        self._link_map = {}
+        self._link_map = OrderedDict()
         self._joint_map: Dict[str, Joint] = {}
         self._transmission_map = {}
         self._material_map = {}

--- a/tests/unit/test_diff_fk.py
+++ b/tests/unit/test_diff_fk.py
@@ -189,7 +189,7 @@ def test_diff_fk():
             linkName: torch.ones((7,), device=DEVICE)
             for linkName in robotDiff._link_map.keys()
         }
-        for jointVelGrad in robotDiff.backward(timeStep, linkGrad):
+        for jointVelGrad in robotDiff.fk_gradient(timeStep, linkGrad):
             assert jointVelGrad != None, f"NONE Gradient at time={timeStep}"         
     
 def test_diff_fk_random_actions():

--- a/tests/unit/test_diff_fk.py
+++ b/tests/unit/test_diff_fk.py
@@ -7,7 +7,7 @@ import torch
 
 from plb.urdfpy import *
 from plb.urdfpy.diff_fk import (
-    TIME_INTERVAL,
+    VELOCITY_SCALE,
     DiffJoint,
     DiffLink,
     _matrix_2_xyz_quat, 
@@ -101,13 +101,13 @@ def test_diff_joint():
         diffJoint.apply_velocity(action1)
         with torch.no_grad():
             assert len(diffJoint.velocities) == 2 and torch.allclose(diffJoint.angle, \
-                action1 * TIME_INTERVAL, rtol=1e-3), \
-                f"applying {action1} to joint, expecting {action1 * TIME_INTERVAL}, get {diffJoint.angle}"
+                action1 * VELOCITY_SCALE, rtol=1e-3), \
+                f"applying {action1} to joint, expecting {action1 * VELOCITY_SCALE}, get {diffJoint.angle}"
         action2 = _tensor_creator(torch.rand, (diffJoint.action_dim, )) * 0.01
         diffJoint.apply_velocity(action2)
         with torch.no_grad():
-            assert len(diffJoint.velocities) == 3 and torch.allclose(diffJoint.angle, (action1 * TIME_INTERVAL + action2 * TIME_INTERVAL), rtol=1e-3), f"applying {action1}, "+\
-                f"{action2} to joint, expecting {action1 * TIME_INTERVAL + action2 * TIME_INTERVAL}, get {diffJoint.angle}"
+            assert len(diffJoint.velocities) == 3 and torch.allclose(diffJoint.angle, (action1 * VELOCITY_SCALE + action2 * VELOCITY_SCALE), rtol=1e-3), f"applying {action1}, "+\
+                f"{action2} to joint, expecting {action1 * VELOCITY_SCALE + action2 * VELOCITY_SCALE}, get {diffJoint.angle}"
 
         # test backward
         action1.retain_grad()
@@ -207,7 +207,7 @@ def test_diff_fk_random_actions():
     for eachAction in actions:
         cfgs.append(
             {
-                jointName: 24 * eachAction[idx].detach().cpu().numpy()
+                jointName: eachAction[idx].detach().cpu().numpy()
                 for idx, jointName in enumerate(diffRobot.actuated_joint_names)
             }
         )

--- a/tests/unit/test_fk.py
+++ b/tests/unit/test_fk.py
@@ -1,4 +1,3 @@
-from os import times
 import pickle
 from typing import Dict, List
 

--- a/tests/unit/test_robot_controller.py
+++ b/tests/unit/test_robot_controller.py
@@ -44,7 +44,7 @@ def test_deflatten_robot_actions():
 
 def test_single_robot():
     rc = RobotsController()
-    robot = DiffRobot.load('tests/data/ur5/ur5.urdf')
+    robot = DiffRobot.load('tests/data/ur5/ur5_primitive.urdf')
 
 
     # test append robot
@@ -108,8 +108,8 @@ def test_single_robot():
 
 def test_dual_robot():
     rc = RobotsController()
-    robotA = DiffRobot.load('tests/data/ur5/ur5.urdf')
-    robotB = DiffRobot.load('tests/data/ur5/ur5.urdf')
+    robotA = DiffRobot.load('tests/data/ur5/ur5_primitive.urdf')
+    robotB = DiffRobot.load('tests/data/ur5/ur5_primitive.urdf')
     
     linkCnt = sum((
         1 for _ in rc.append_robot(robotA)

--- a/tests/unit/test_robot_controller.py
+++ b/tests/unit/test_robot_controller.py
@@ -9,8 +9,6 @@ from plb.urdfpy import DiffRobot, Link, FK_CFG_Type, Mesh
 
 taichi.init()
 
-#TODO: modify the sections where set_robot_action is called
-
 def test_deflatten_robot_actions():
     robot = DiffRobot.load('tests/data/ur5/ur5.urdf')
     robotActionDim = sum((

--- a/tests/unit/test_robot_controller.py
+++ b/tests/unit/test_robot_controller.py
@@ -9,6 +9,8 @@ from plb.urdfpy import DiffRobot, Link, FK_CFG_Type, Mesh
 
 taichi.init()
 
+#TODO: modify the sections where set_robot_action is called
+
 def test_deflatten_robot_actions():
     robot = DiffRobot.load('tests/data/ur5/ur5.urdf')
     robotActionDim = sum((
@@ -84,13 +86,13 @@ def test_single_robot():
         f" but expecting [0, 3, 6, 9, {robotActionDim}]"
     
     # test set robot actions
-    envAction = [0.33, 0.66, 0.72] + [
+    envAction = [
         torch.rand((1,), device='cuda', dtype=torch.float64, requires_grad=True)
         for _ in range(robotActionDim)
     ]
-    rc.set_robot_actions(envAction, 3)
+    rc.set_action(0, 1, envAction)
     poseA: Dict[Link, Any] = robot._current_cfg
-    robot.link_fk(envAction[3:], cfgType=FK_CFG_Type.angle)
+    robot.link_fk(envAction, cfgType=FK_CFG_Type.angle)
     poseB: Dict[Link, Any] = robot._current_cfg
     poseA = {
         link.name : pose
@@ -158,13 +160,13 @@ def test_dual_robot():
         f"after appending robot's action dims, the action_dims become {action_dims},"+\
         f" but expecting [0, 3, 6, 9, {robotActionDim}, {robotActionDim}]"
     
-    envAction = [0.33, 0.66, 0.72] + [
+    envAction = [
         torch.rand((1,), device='cuda', dtype=torch.float64, requires_grad=True)
         for _ in range(robotActionDim * 2)
     ]
-    rc.set_robot_actions(envAction, 3)
+    rc.set_action(0, 1, envAction)
     poseA: Dict[Link, Any] = robotB._current_cfg
-    robotB.link_fk(envAction[3 + robotActionDim:], cfgType=FK_CFG_Type.angle)
+    robotB.link_fk(envAction[robotActionDim:], cfgType=FK_CFG_Type.angle)
     poseB: Dict[Link, Any] = robotB._current_cfg
     poseA = {
         link.name : pose

--- a/tests/unit/test_robot_grad.py
+++ b/tests/unit/test_robot_grad.py
@@ -1,0 +1,47 @@
+import taichi
+import torch
+
+from plb.engine.primitive import Primitives
+from plb.engine.robots import RobotsController
+from plb.urdfpy import DiffRobot
+
+taichi.init()
+
+def test_robot_and_primitives():
+    primitives = Primitives([]) # empty primitives
+    # robot = DiffRobot.load("tests/data/ur5/ur5_primitive.urdf")
+    robot = DiffRobot.load("tests/data/ur5/ur5.urdf")
+    rc = RobotsController()
+    for shape in rc.append_robot(robot, (0.0, 0.0, 0.0)):
+        primitives.primitives.append(shape)
+    assert primitives.n == 0, f"No free primitives expected, but got {primitives.n}"
+    assert len(primitives.primitives) == 1, \
+        f"8 primitives from the robot is expected, but got {len(primitives.primitives)}"
+
+    action_dims = primitives.action_dims.copy()
+    assert len(action_dims) == 1 and action_dims[0] == 0, \
+        f"primitives.action_dims is expected to be [0], but got {action_dims}"
+    rc.export_action_dims(to = action_dims)
+    assert len(action_dims) == 2 and action_dims[0] == 0 and action_dims[1] == 6, \
+        f"action_dims after the robot's exporting is expected to be [0,6], but got {action_dims}"
+
+    primitives.initialize()
+
+    # forward pass
+    actions = torch.rand((7,))
+    rc.set_action(0, 5, actions)
+    actions = torch.rand((7,))
+    rc.set_action(1, 5, actions)
+    for i in range(10):
+        rc.forward_kinematics(i)
+
+    # backward pass
+    for i in range(9, -1, -1):
+        rc.forward_kinematics.grad(i)
+
+    grad = rc.get_step_grad(0)
+    assert len(grad) != 0 and all((each_grad != None for each_grad in grad)), \
+        f"Gradient backpropagation fails: step[0] gradient = {grad}"
+    grad = rc.get_step_grad(1)
+    assert len(grad) != 0 and all((each_grad != None for each_grad in grad)), \
+        f"Gradient backpropagation fails: step[1] gradient = {grad}"

--- a/tests/unit/test_robot_grad.py
+++ b/tests/unit/test_robot_grad.py
@@ -9,13 +9,12 @@ taichi.init()
 
 def test_robot_and_primitives():
     primitives = Primitives([]) # empty primitives
-    # robot = DiffRobot.load("tests/data/ur5/ur5_primitive.urdf")
-    robot = DiffRobot.load("tests/data/ur5/ur5.urdf")
+    robot = DiffRobot.load("tests/data/ur5/ur5_primitive.urdf")
     rc = RobotsController()
     for shape in rc.append_robot(robot, (0.0, 0.0, 0.0)):
         primitives.primitives.append(shape)
     assert primitives.n == 0, f"No free primitives expected, but got {primitives.n}"
-    assert len(primitives.primitives) == 1, \
+    assert len(primitives.primitives) == 8, \
         f"8 primitives from the robot is expected, but got {len(primitives.primitives)}"
 
     action_dims = primitives.action_dims.copy()


### PR DESCRIPTION
# Gradient Backpropagation

Optimize the bridge between the robots' forward kinematics and the primitives' forward kinematics, and modify the gradient backpropagation accordingly. 

## Detailed modifications

### `plb/engine/controller.py`
A newly-added abstraction to generalize the common behaviours of `plb.engine.RobotController` and `plb.engine.primitive.Primitives` _(the controller for free primitives)_. The controllers are used in the MPM simulator. The following interfaces are exposed to the simulator:
1. `controller.set_action(index, substeps, action)` -> set action for whatever being controlled by the controller
1. `controller.forward_kinematics(index)` -> execute the previously set actions
1. `controller.forward_kinematics.grad(index)` -> gradient backpropagation of the `forward_kinematics` method

The controller's forward kinematics and its gradient backpropagation method are designed in the above way to be compatible with Taichi's complex kernel. 

### `plb/engine/mpm_simulator.py`
1. Utilize the `Controller` interfaces to control movable stuff to interact with the environment
1. Allows `torch.Tensor`

### `plb/engine/primitive/primitives.py`
Inheriting the `Controller`

### `plb/engine/primitive/primive_base.py`
Add a complex kernel called `apply_robot_forward_kinematics`. 

The kernel is designed for the `RobotController` to directly apply the results from the robot's forward kinematics onto each primitive. Previously, differentiation and conversion were necessary since the robot's FK gives each link's pose, but a primitive only accepts a 6-dim velocity as inputs. The new kernel offers a shortcut to apply poses on primitives without converting them into speeds directly. 

### `plb/engine/taichi_env.py`
Use the `Controller` interfaces to replace the original `Primitives` and `RobotController`. 

### `plb/urdfpy/__init__.py`
The `DEVICE`, i.e.,  where the robots' components are loaded, is exposed. 

### `plb/urdfpy/diff_fk.py`

Gradient backpropagation is fixed here. 

### `plb/urdfpy/manipulation.py`

Use OrderDict to replace Dict for `robot._link_map` to ensure that the backpropagation happens precisely in the forward pass's reversed order.

## Tests

### Unit tests
All passed
![image](https://user-images.githubusercontent.com/43565614/153831802-c2d2a5d7-03e8-4e55-bd4a-50aa8c89a1c6.png)

#### Existing unit tests

Some tests are modified due to the alteration of the method signatures and interfaces. 

#### Newly added test: `tests/unit/test_robot_grad.py`

Ensure the gradient pass of the forward kinematics is correct. 

### Functional tests
N/A, because of the OOM issue of TaichiEnv. 